### PR TITLE
[TEST]: Flying out of the grid

### DIFF
--- a/mars-exploration.test.js
+++ b/mars-exploration.test.js
@@ -123,6 +123,24 @@ describe("Mars exploration unit tests", () => {
       });
     });
 
+    it("should NOT fly to north if probe direction is north and the probe is at the grid border", () => {
+        const customProbeConfig = {
+          ...probeConfig,
+          startDirection: "N",
+          startPosition: [5, 5],
+        };
+        const commands = ["M"];
+  
+        const Probe = new ProbeClass(customProbeConfig);
+  
+        const result = Probe.sendCommands(commands);
+  
+        expect(result).toEqual({
+          position: [5, 5],
+          direction: customProbeConfig.startDirection,
+        });
+      });
+
     it("should fly to east if probe direction is east", () => {
         const customProbeConfig = {
           ...probeConfig,
@@ -137,6 +155,24 @@ describe("Mars exploration unit tests", () => {
   
         expect(result).toEqual({
           position: [1, 0],
+          direction: customProbeConfig.startDirection,
+        });
+      });
+
+      it("should NOT fly to east if probe direction is east and the probe is at the grid border", () => {
+        const customProbeConfig = {
+          ...probeConfig,
+          startDirection: "E",
+          startPosition: [5, 5],
+        };
+        const commands = ["M"];
+  
+        const Probe = new ProbeClass(customProbeConfig);
+  
+        const result = Probe.sendCommands(commands);
+  
+        expect(result).toEqual({
+          position: [5, 5],
           direction: customProbeConfig.startDirection,
         });
       });
@@ -159,6 +195,24 @@ describe("Mars exploration unit tests", () => {
         });
       });
 
+      it("should NOT fly to south if probe direction is south and the probe is at the grid border", () => {
+        const customProbeConfig = {
+          ...probeConfig,
+          startDirection: "S",
+          startPosition: [0, 0],
+        };
+        const commands = ["M"];
+  
+        const Probe = new ProbeClass(customProbeConfig);
+  
+        const result = Probe.sendCommands(commands);
+  
+        expect(result).toEqual({
+          position: [0, 0],
+          direction: customProbeConfig.startDirection,
+        });
+      });
+
       it("should fly to west if probe direction is west", () => {
         const customProbeConfig = {
           ...probeConfig,
@@ -173,6 +227,24 @@ describe("Mars exploration unit tests", () => {
   
         expect(result).toEqual({
           position: [0, 1],
+          direction: customProbeConfig.startDirection,
+        });
+      });
+
+      it("should NOT fly to west if probe direction is west and the probe is at the grid border", () => {
+        const customProbeConfig = {
+          ...probeConfig,
+          startDirection: "W",
+          startPosition: [0, 0],
+        };
+        const commands = ["M"];
+  
+        const Probe = new ProbeClass(customProbeConfig);
+  
+        const result = Probe.sendCommands(commands);
+  
+        expect(result).toEqual({
+          position: [0, 0],
           direction: customProbeConfig.startDirection,
         });
       });


### PR DESCRIPTION
This PR adds missing tests for probe behaviour when the position is at the edge of the grid, so the probe should not move beyond the grid.

Sorry, forget about these tests :smile: 